### PR TITLE
feat: Add TLS support

### DIFF
--- a/check_clickhouse
+++ b/check_clickhouse
@@ -62,16 +62,18 @@ query() {
   [ -z "$CH_HOST" ]     || cmd="${cmd} -h ${CH_HOST}"
   [ -z "$CH_USER" ]     || cmd="${cmd} -u ${CH_USER}"
   [ -z "$CH_PASS" ]     || cmd="${cmd} --password ${CH_PASS}"
+  [ -n "$CH_SECURE" ] && [ "$CH_SECURE" == "1" ] && cmd="${cmd} --secure"
   ${cmd} -q "${sql}" 2> /dev/null
 }
 
 usage() {
   tabs 2
-  echo "Usage: ${PROGNAME} -m <mode> [-u <user>] [-p <pass>] [-l 0|1] [-w <warning>] [-c <critical>] [-h]"
+  echo "Usage: ${PROGNAME} -m <mode> [-u <user>] [-p <pass>] [-l 0|1] [-t 0|1] [-w <warning>] [-c <critical>] [-h]"
   echo
   echo -e "\t-s <host>\tClickHouse host address (default 'localhost')"
   echo -e "\t-u <user>\tClickHouse user (default 'default')"
   echo -e "\t-p <pass>\tClickHouse password (empty by default)"
+  echo -e "\t-t <0|1>\tDisable/Enable TLS connection (disabled by default)"
   echo -e "\t-l <0|1>\tDisable/Enable query logging (default depends on user's profile settings)"
   echo -e "\t-m <mode>\tMode to run (see below)"
   echo -e "\t-w <warning>\tWarning threshold (default depends on the mode, see below)"
@@ -93,7 +95,7 @@ usage() {
 }
 
 check_arguments() {
-  while getopts ":hm:w:c:u:s:p:l:" opt
+  while getopts ":hm:w:c:u:s:p:t:l:" opt
   do
     case $opt in
       h )
@@ -117,6 +119,9 @@ check_arguments() {
       p )
         CH_PASS=$OPTARG
         ;;
+      t )
+        CH_SECURE=$OPTARG
+        ;;
       l )
         LOG_QUERIES=$OPTARG
         ;;
@@ -135,6 +140,7 @@ check_arguments() {
   [ -z "${mode}" ] && usage
   [[ -n "${modes[$mode]}" ]] || fail "Mode '${mode}' isn't supported."
   [[ "${LOG_QUERIES}" =~ ^[0|1]?$ ]] || fail "Option log queries (-l) can only be 0 or 1"
+  [[ "${CH_SECURE}" =~ ^[0|1]?$ ]] || fail "Option secure (-t) can only be 0 or 1"
 
   # Default thresholds
   if [ -z $warn ]


### PR DESCRIPTION
Hello folks,

When TLS is enabled, the clickhouse-client must use the `--secure` option to connect. This commit adds a new argument `-t 0|1`, because `-s` was already used to define the host, to disable or enable the secure more. Only the `-t 1` will enable the mode. Other options are ignored.

Example without the secure mode (default):
```
# ./check_clickhouse -m replication_active_replicas
REPLICATION_ACTIVE_REPLICAS CRITICAL: Unable to reach clickhouse
```
With the secure mode:
```
# ./check_clickhouse -m replication_active_replicas -t 1
REPLICATION_ACTIVE_REPLICAS OK: All tables have active_replicas=2
```
Without the secure mode but the argument provided:
```
# ./check_clickhouse -m replication_active_replicas -t 0
REPLICATION_ACTIVE_REPLICAS CRITICAL: Unable to reach clickhouse
```
With invalid arguments:
```
# ./check_clickhouse -m replication_active_replicas -t
Option '-t' requires an argument.
# ./check_clickhouse -m replication_active_replicas -t x
Option secure (-t) can only be 0 or 1
```

I wish you to have a nice day,
Julien